### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Requirements
 
         * Ubuntu
 
-            * Xenial (16.04)
             * Bionic (18.04)
 
 Role Variables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,8 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
-        - xenial
         - bionic
   galaxy_tags:
     - pipenv

--- a/molecule/ubuntu_min/molecule.yml
+++ b/molecule/ubuntu_min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible_role_pipenv_ubuntu_min
-    image: ubuntu:16.04
+    image: ubuntu:18.04
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
The latest version of pip doesn't work with the version of Python that comes with Ubuntu 16.04 (Python 3.5).